### PR TITLE
Ayaneo Air 1S oxp-sensors implementation broken

### DIFF
--- a/backend/fan_config/hwmon/oxpec.yml
+++ b/backend/fan_config/hwmon/oxpec.yml
@@ -6,6 +6,7 @@ fans:
     pwm_mode: 0 # 写入的模式 0.普通模式(对单个文件写入) 1.rog掌机特殊模式(对多个文件写入同样的数值)
     black_list: # 黑名单, 匹配 /sys/devices/virtual/dmi/id/product_name. 不使用该配置
       - G1618-04
+      - AIR 1S
       # - G1617-01
 
     pwm_enable:


### PR DESCRIPTION
The oxp-sensors mainline driver uses the wrong register for setting fan speed, so EC is the only answer. The EC config in this project seems to work. I'm going to work on an actual fix, starting with the [ChimeraOS developers](https://github.com/ChimeraOS/chimeraos/issues/1042) but this is needed in the meantime.